### PR TITLE
add options on content_put operation

### DIFF
--- a/foedus/src/Error.cpp
+++ b/foedus/src/Error.cpp
@@ -32,6 +32,8 @@ StatusCode resolve(::foedus::ErrorStack const& result) {
     switch(result.get_error_code()) {
         case ::foedus::kErrorCodeStrKeyNotFound:
             return StatusCode::NOT_FOUND;
+        case ::foedus::kErrorCodeStrKeyAlreadyExists:
+            return StatusCode::ALREADY_EXISTS;
         case ::foedus::ErrorCode::kErrorCodeXctUserAbort:
             return StatusCode::USER_ROLLBACK;
         case ::foedus::ErrorCode::kErrorCodeUserDefined:

--- a/foedus/src/Storage.cpp
+++ b/foedus/src/Storage.cpp
@@ -46,10 +46,21 @@ StatusCode Storage::get(Transaction* tx, Slice key, std::string &buffer) {
     return resolve(rc);
 }
 
-StatusCode Storage::put(Transaction* tx, Slice key, Slice value) {
-    return resolve(masstree_.upsert_record(tx->context(),
-        key.data(), static_cast<::foedus::storage::masstree::KeyLength>(key.size()),
-        value.data(), static_cast<::foedus::storage::masstree::PayloadLength>(value.size())));
+StatusCode Storage::put(Transaction* tx, Slice key, Slice value, PutOperation operation) {
+    switch(operation) {
+        case PutOperation::CREATE:
+            return resolve(masstree_.insert_record(tx->context(),
+                         key.data(), static_cast<::foedus::storage::masstree::KeyLength>(key.size()),
+                         value.data(), static_cast<::foedus::storage::masstree::PayloadLength>(value.size())));
+        case PutOperation::UPDATE:
+            return resolve(masstree_.overwrite_record(tx->context(),
+                         key.data(), static_cast<::foedus::storage::masstree::KeyLength>(key.size()),
+                         value.data(), 0U, static_cast<::foedus::storage::masstree::PayloadLength>(value.size())));
+        default:
+            return resolve(masstree_.upsert_record(tx->context(),
+                         key.data(), static_cast<::foedus::storage::masstree::KeyLength>(key.size()),
+                         value.data(), static_cast<::foedus::storage::masstree::PayloadLength>(value.size())));
+    }
 }
 
 StatusCode Storage::remove(Transaction* tx, Slice key) {

--- a/foedus/src/Storage.h
+++ b/foedus/src/Storage.h
@@ -71,9 +71,10 @@ public:
      * @param tx the transaction where the operation is executed
      * @param key the entry key
      * @param value the entry value
+     * @param operation type of the put operation
      * @return the operation status
      */
-    StatusCode put(Transaction* tx, Slice key, Slice value);
+    StatusCode put(Transaction* tx, Slice key, Slice value, PutOperation operation);
 
     /**
      * @brief removes an entry.

--- a/foedus/src/api.cpp
+++ b/foedus/src/api.cpp
@@ -160,14 +160,15 @@ StatusCode content_put(
     TransactionHandle transaction,
     StorageHandle storage,
     Slice key,
-    Slice value) {
+    Slice value,
+    PutOperation operation) {
     auto tx = unwrap(transaction);
     auto stg = unwrap(storage);
     auto database = tx->owner();
     if (!database) {
         return StatusCode::ERR_INVALID_STATE;
     }
-    return stg->put(tx, key, value);
+    return stg->put(tx, key, value, operation);
 }
 
 StatusCode content_delete(

--- a/foedus/test/ApiTest.cpp
+++ b/foedus/test/ApiTest.cpp
@@ -570,6 +570,76 @@ TEST_F(FoedusApiTest, contents) {
     EXPECT_EQ(database_close(db), StatusCode::OK);
 }
 
+TEST_F(FoedusApiTest, put_operations) {
+    DatabaseOptions options;
+    options.attribute(KEY_LOCATION, path());
+
+    DatabaseHandle db;
+    ASSERT_EQ(database_open(options, &db), StatusCode::OK);
+    HandleHolder dbh { db };
+
+    struct S {
+        static TransactionOperation update_miss(TransactionHandle tx, void* args) {
+            auto st = extract<S>(args);
+            if (content_put(tx, st, "a", "A", PutOperation::UPDATE) != StatusCode::NOT_FOUND) {
+                return TransactionOperation::ERROR;
+            }
+            return TransactionOperation::COMMIT;
+        }
+        static TransactionOperation create(TransactionHandle tx, void* args) {
+            auto st = extract<S>(args);
+            Slice s;
+            if (content_put(tx, st, "a", "A", PutOperation::CREATE) != StatusCode::OK) {
+                return TransactionOperation::ERROR;
+            }
+            return TransactionOperation::COMMIT;
+        }
+        static TransactionOperation check_create(TransactionHandle tx, void* args) {
+            auto st = extract<S>(args);
+            Slice s;
+            if (content_get(tx, st, "a", &s) != StatusCode::OK) {
+                return TransactionOperation::ERROR;
+            }
+            if (s != "A") {
+                return TransactionOperation::ERROR;
+            }
+            return TransactionOperation::COMMIT;
+        }
+        static TransactionOperation create_when_exists_then_update(TransactionHandle tx, void* args) {
+            auto st = extract<S>(args);
+            if (content_put(tx, st, "a", "N", PutOperation::CREATE) != StatusCode::ALREADY_EXISTS) {
+                return TransactionOperation::ERROR;
+            }
+            if (content_put(tx, st, "a", "B", PutOperation::UPDATE) != StatusCode::OK) {
+                return TransactionOperation::ERROR;
+            }
+            return TransactionOperation::COMMIT;
+        }
+        static TransactionOperation check_update(TransactionHandle tx, void* args) {
+            auto st = extract<S>(args);
+            Slice s;
+            if (content_get(tx, st, "a", &s) != StatusCode::OK) {
+                return TransactionOperation::ERROR;
+            }
+            if (s != "B") {
+                return TransactionOperation::ERROR;
+            }
+            return TransactionOperation::COMMIT;
+        }
+        StorageHandle st;
+    };
+    S s;
+    ASSERT_EQ(storage_create(db, "s", &s.st), StatusCode::OK);
+    HandleHolder sth { s.st };
+
+    EXPECT_EQ(transaction_exec(db, {}, &S::update_miss, &s), StatusCode::OK);
+    EXPECT_EQ(transaction_exec(db, {}, &S::create, &s), StatusCode::OK);
+    EXPECT_EQ(transaction_exec(db, {}, &S::check_create, &s), StatusCode::OK);
+    EXPECT_EQ(transaction_exec(db, {}, &S::create_when_exists_then_update, &s), StatusCode::OK);
+    EXPECT_EQ(transaction_exec(db, {}, &S::check_update, &s), StatusCode::OK);
+    EXPECT_EQ(database_close(db), StatusCode::OK);
+}
+
 TEST_F(FoedusApiTest, scan_prefix) {
     DatabaseOptions options;
     options.attribute(KEY_LOCATION, path());

--- a/include/sharksfin/api.h
+++ b/include/sharksfin/api.h
@@ -214,19 +214,42 @@ extern "C" StatusCode content_get(
         Slice* result);
 
 /**
+ * @brief options for put operation
+ */
+enum class PutOperation : std::uint32_t {
+    /**
+     * @brief to update the existing entry, or create new one if the entry doesn't exist.
+     */
+    CREATE_OR_UPDATE = 0U,
+
+    /**
+     * @brief to create new entry. StatusCode::ALREADY_EXISTS is returned from put operation if the entry already exist.
+     */
+    CREATE,
+
+    /**
+     * @brief to update existing entry. StatusCode::NOT_FOUND is returned from put operation if the entry doesn't exist.
+     */
+    UPDATE,
+};
+
+/**
  * @brief puts a content onto the target key.
  * @param transaction the current transaction handle
  * @param storage the target storage
  * @param key the content key
  * @param value the content value
+ * @param operation indicates the behavior with the existing/new entry. See PutOperation.
  * @return Status::OK if the target content was successfully put
+ * @return warnings if the operation is not applicable to the entry. See PutOperation.
  * @return otherwise if error was occurred
  */
 extern "C" StatusCode content_put(
         TransactionHandle transaction,
         StorageHandle storage,
         Slice key,
-        Slice value);
+        Slice value,
+        PutOperation operation = PutOperation::CREATE_OR_UPDATE);
 
 /**
  * @brief removes a content on the target key.

--- a/mock/src/Storage.h
+++ b/mock/src/Storage.h
@@ -80,7 +80,7 @@ public:
      * @param value the entry value
      * @return the operation status
      */
-    StatusCode put(Slice key, Slice value);
+    StatusCode put(Slice key, Slice value, PutOperation operation = PutOperation::CREATE_OR_UPDATE);
 
     /**
      * @brief removes an entry.

--- a/mock/src/api.cpp
+++ b/mock/src/api.cpp
@@ -189,13 +189,14 @@ StatusCode content_put(
         TransactionHandle transaction,
         StorageHandle storage,
         Slice key,
-        Slice value) {
+        Slice value,
+        PutOperation operation) {
     auto tx = unwrap(transaction);
     auto st = unwrap(storage);
     if (!tx->is_alive()) {
         return StatusCode::ERR_INVALID_STATE;
     }
-    return st->put(key, value);
+    return st->put(key, value, operation);
 }
 
 StatusCode content_delete(


### PR DESCRIPTION
To distinguish INSERT/UPDATE/UPSERT sql operations, this PR adds PutOperation flag to content_put().