### PR TITLE
test: improve test

### DIFF
--- a/shirakami/test/ccTest.cpp
+++ b/shirakami/test/ccTest.cpp
@@ -317,18 +317,20 @@ TEST_F(ShirakamiCCTest, get_concurrently) {
         std::unique_ptr<Storage> st{};
         EXPECT_EQ(db->get_storage("S", st), StatusCode::OK);
         std::size_t row_count = 0;
-        for (std::size_t i = 0U; i < COUNT; ++i) {
+        for (std::size_t i = 0U; i < COUNT;) {
             std::string buf{};
             auto rc = st->get(tx2.get(), "aX"s+std::to_string(i), buf);
             EXPECT_TRUE(rc == StatusCode::OK || rc == StatusCode::NOT_FOUND || rc == StatusCode::ERR_ABORTED_RETRYABLE);
-            if (rc == StatusCode::ERR_ABORTED_RETRYABLE) {
+            if (rc != StatusCode::OK) {
                 std::this_thread::sleep_for(std::chrono::milliseconds(1));
+                tx2->abort();
                 tx2->reset();
                 continue;
             }
             EXPECT_EQ(tx2->commit(), StatusCode::OK);
             if (rc == StatusCode::OK) {
                 ++row_count;
+                ++i;
             }
             tx2->reset();
         }


### PR DESCRIPTION
テスト内容の改善に関してです。

L320: ++i を消した理由：L331 の commit で成功した際に row_count をインクリメントしていることから、一件ずつ読み、正常に読めたら次のエントリを読むというテストシナリオだと思います。
一件正常に読めたら次のエントリを読むことを試み、失敗したら同じエントリを成功するまで読み込もうとするためにそうしました。

L324: NOT_FOUND のときも期待通り読めていないので、リトライするようにしました。

L333: 成功したときに次のエントリの読み込みを試みるためにインクリメントするようにしました。

作業の由来は下記コメントに基づいています。
https://github.com/project-tsurugi/tsurugi-issues/issues/666#issuecomment-1970686164