### PR TITLE
add missing include (for FTBFS test-code with gcc-13)

### DIFF
--- a/include/sharksfin/StorageOptions.h
+++ b/include/sharksfin/StorageOptions.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 Project Tsurugi.
+ * Copyright 2018-2024 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #define SHARKSFIN_STORAGEOPTIONS_H_
 
 #include <cstddef>
+#include <cstdint>
 #include <vector>
 #include <iostream>
 #include <limits>

--- a/include/sharksfin/TransactionOptions.h
+++ b/include/sharksfin/TransactionOptions.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 Project Tsurugi.
+ * Copyright 2018-2024 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #define SHARKSFIN_TRANSACTIONOPTIONS_H_
 
 #include <cstddef>
+#include <cstdint>
 #include <vector>
 #include <iostream>
 #include <limits>


### PR DESCRIPTION
#32 で `<cstdint>` の include が足りていない箇所の修正をしましたが、テストコードから使われている部分が未解消だったため、それを含めてもう少し網羅的に修正しました。