### PR TITLE
build: make RPATH relative

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -62,6 +62,6 @@ runs:
         rm -fr build
         mkdir build
         cd build
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_BENCHMARK=OFF -DFORCE_INSTALL_RPATH=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_BENCHMARK=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
         cmake --build . --target install --clean-first
       shell: bash

--- a/.vscode/samples/settings.json
+++ b/.vscode/samples/settings.json
@@ -1,7 +1,6 @@
 {
     "cmake.configureArgs": [
         "-DCMAKE_PREFIX_PATH=${env:HOME}/git/.opt",
-        "-DFORCE_INSTALL_RPATH=ON",
         "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
         "-DCMAKE_BUILD_TYPE=${env:BUILD_TYPE}"
     ],

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,10 @@ option(BUILD_DOCUMENTS "Build documents" ON)
 option(INSTALL_EXAMPLES "Install example programs" OFF)
 option(FORCE_INSTALL_RPATH "Force add lib dir of custom prefixes to INSTALL_RPATH" OFF)
 
+if (FORCE_INSTALL_RPATH)
+    message(DEPRECATION "FORCE_INSTALL_RPATH is obsoleted")
+endif (FORCE_INSTALL_RPATH)
+
 option(ENABLE_SANITIZER "enable sanitizer on debug build" ON)
 option(ENABLE_UB_SANITIZER "enable undefined behavior sanitizer on debug build" OFF)
 option(ENABLE_COVERAGE "enable coverage on debug build" OFF)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ available options:
 * `-DBUILD_SHIRAKAMI=OFF` - never build shirakami bridge
 * `-DBUILD_EXAMPLES=OFF` - never build example programs
 * `-DBUILD_DOCUMENTS=OFF` - never build documents by doxygen
-* `-DFORCE_INSTALL_RPATH=ON` - force set RPATH for non-default library paths
 * `-DINSTALL_EXAMPLES=ON` - also install example programs (requires `BUILD_EXAMPLES` is enables)
 * `-DEXAMPLE_IMPLEMENTATION=...` - link the specified target-name implementation to example programs
   * `memory` - link to in-memory implementation (default)
@@ -54,7 +53,7 @@ available options:
   * `-DENABLE_UB_SANITIZER=ON` - enable undefined behavior sanitizer (requires `-DENABLE_SANITIZER=ON`)
   * `-DENABLE_COVERAGE=ON` - enable code coverage analysis (requires `-DCMAKE_BUILD_TYPE=Debug`)
   * `-DBUILD_SHARED_LIBS=OFF` - create static libraries instead of shared libraries
-  
+
 ### install
 
 ```sh
@@ -73,8 +72,8 @@ ctest -V
 cmake --build . --target doxygen
 ```
 
-### Customize logging setting 
-Sharksfin internally uses [glog](https://github.com/google/glog) so you can pass glog environment variables such as `GLOG_logtostderr=1` to customize the logging output of executable that uses sharksfin. 
+### Customize logging setting
+Sharksfin internally uses [glog](https://github.com/google/glog) so you can pass glog environment variables such as `GLOG_logtostderr=1` to customize the logging output of executable that uses sharksfin.
 
 ```sh
 GLOG_logtostderr=1 ./sharksfin-cli -Dlocation=./db1 put 0 A

--- a/cmake/InstallOptions.cmake
+++ b/cmake/InstallOptions.cmake
@@ -28,37 +28,6 @@ function(install_custom target_name export_name)
             DESTINATION ${CMAKE_INSTALL_BINDIR}
             COMPONENT Runtime
     )
-    # Add INSTALL_RPATH from CMAKE_INSTALL_PREFIX and CMAKE_PREFIX_PATH
-    # The default behavior of CMake omits RUNPATH if it is already in CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES.
-    if (FORCE_INSTALL_RPATH)
-        get_target_property(target_type ${target_name} TYPE)
-        if (target_type STREQUAL "SHARED_LIBRARY"
-                OR target_type STREQUAL "EXECUTABLE")
-            get_target_property(rpath ${target_name} INSTALL_RPATH)
-
-            # add ${CMAKE_INSTALL_PREFIX}/lib if it is not in system link directories
-            get_filename_component(p "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" ABSOLUTE)
-            list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${p}" is_system)
-            if (is_system STREQUAL "-1")
-                list(APPEND rpath "${p}")
-            endif()
-
-            # add each ${CMAKE_PREFIX_PATH}/lib
-            foreach (p IN LISTS CMAKE_PREFIX_PATH)
-                get_filename_component(p "${p}/${CMAKE_INSTALL_LIBDIR}" ABSOLUTE)
-                list(APPEND rpath "${p}")
-            endforeach()
-
-            if (rpath)
-                set_target_properties(${target_name} PROPERTIES
-                    INSTALL_RPATH "${rpath}")
-            endif()
-
-            # add other than */lib paths
-            set_target_properties(${target_name} PROPERTIES
-                INSTALL_RPATH_USE_LINK_PATH ON)
-        endif()
-    endif (FORCE_INSTALL_RPATH)
     # Install include files of interface libraries manually
     # INTERFACE_INCLUDE_DIRECTORIES must contains the following entries:
     # - one or more `$<BUILD_INTERFACE:...>` paths (may be absolute paths on source-tree)

--- a/examples/cli/CMakeLists.txt
+++ b/examples/cli/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(cli
 
 set_target_properties(cli
     PROPERTIES
+        INSTALL_RPATH "\$ORIGIN/../lib"
         RUNTIME_OUTPUT_NAME "sharksfin-cli"
 )
 

--- a/memory/src/CMakeLists.txt
+++ b/memory/src/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(memory
 
 set_target_properties(memory
     PROPERTIES
+        INSTALL_RPATH "\$ORIGIN/../lib"
         LIBRARY_OUTPUT_NAME "sharksfin-memory"
 )
 

--- a/shirakami/src/CMakeLists.txt
+++ b/shirakami/src/CMakeLists.txt
@@ -12,7 +12,8 @@ add_library(shirakami
 
 set_target_properties(shirakami
         PROPERTIES
-        LIBRARY_OUTPUT_NAME "sharksfin-shirakami"
+                INSTALL_RPATH "\$ORIGIN/../lib"
+                LIBRARY_OUTPUT_NAME "sharksfin-shirakami"
         )
 
 target_compile_definitions(shirakami


### PR DESCRIPTION
This Pull Request modifies CMake Property `INSTALL_RPATH` to relative path based `$ORIGIN`, and changes to disable unnecessary CMake Property `FORCE_INSTALL_RPATH`.