### PR TITLE
fall back to Boost::stacktrace_basic if Boost::stacktrace_backtrace is not available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 Project Tsurugi.
+# Copyright 2018-2024 Project Tsurugi.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -51,9 +51,17 @@ find_package(Doxygen)
 find_package(Threads REQUIRED)
 find_package(Boost 1.65
         COMPONENTS filesystem
-        COMPONENTS stacktrace_backtrace
+        OPTIONAL_COMPONENTS stacktrace_backtrace stacktrace_basic
         REQUIRED
         )
+if(Boost_STACKTRACE_BACKTRACE_FOUND
+   AND (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
+    set(boost_stacktrace_component stacktrace_backtrace)
+elseif(Boost_STACKTRACE_BASIC_FOUND)
+    set(boost_stacktrace_component stacktrace_basic)
+else()
+    message(FATAL_ERROR "No usable Boost stacktrace component")
+endif()
 find_package(glog)
 find_package(numa)
 find_package(shirakami)

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 Project Tsurugi.
+# Copyright 2018-2024 Project Tsurugi.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,5 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+include(CMakeFindDependencyMacro)
+find_dependency(Boost 1.65 COMPONENTS @boost_stacktrace_component@ REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/@package_name@-targets.cmake")

--- a/shirakami/src/CMakeLists.txt
+++ b/shirakami/src/CMakeLists.txt
@@ -30,7 +30,7 @@ target_link_libraries(shirakami
         PRIVATE glog::glog
         PRIVATE shirakami-shirakami
         PUBLIC Boost::boost
-        PUBLIC Boost::stacktrace_backtrace
+        PUBLIC Boost::${boost_stacktrace_component}
         PUBLIC ${CMAKE_DL_LIBS}
         )
 


### PR DESCRIPTION
Debian/Ubuntu 以外の環境 (FreeBSD や RedHat 系 Linux ディストリビューション) では、
標準提供されているパッケージでは Boost::stacktrace_backtrace が使えないことが多いため、
使えない環境では Boost::stacktrace_basic を使うようにする変更です。

project-tsurugi/takatori#40 の sharksfin 版です。

sharksfin に依存するが takatori に依存しない、というコンポーネントがないようなので、推移的依存関係の修正をしなくてもビルドは通りますが、原理原則として、という面と、将来コンポーネント間関係が変わる可能性もあるので、という面で、その修正も入れてあります。