### PR TITLE
build: fix RPATH settings to work even if libdir is not "lib"

### DIFF
--- a/examples/cli/CMakeLists.txt
+++ b/examples/cli/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 Project Tsurugi.
+# Copyright 2018-2025 Project Tsurugi.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ add_executable(cli
 
 set_target_properties(cli
     PROPERTIES
-        INSTALL_RPATH "\$ORIGIN/../lib"
+        INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}"
         RUNTIME_OUTPUT_NAME "sharksfin-cli"
 )
 

--- a/memory/src/CMakeLists.txt
+++ b/memory/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 Project Tsurugi.
+# Copyright 2018-2025 Project Tsurugi.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ add_library(memory
 
 set_target_properties(memory
     PROPERTIES
-        INSTALL_RPATH "\$ORIGIN/../lib"
+        INSTALL_RPATH "\$ORIGIN"
         LIBRARY_OUTPUT_NAME "sharksfin-memory"
 )
 

--- a/shirakami/src/CMakeLists.txt
+++ b/shirakami/src/CMakeLists.txt
@@ -12,7 +12,7 @@ add_library(shirakami
 
 set_target_properties(shirakami
         PROPERTIES
-                INSTALL_RPATH "\$ORIGIN/../lib"
+                INSTALL_RPATH "\$ORIGIN"
                 LIBRARY_OUTPUT_NAME "sharksfin-shirakami"
         )
 


### PR DESCRIPTION
Tsurugi が主にサポートしている Ubuntu では、インストールディレクトリの下に `lib` ディレクトリを作成し、そこに共有ライブラリファイルを配置しますが、
RHEL 派生 Linux ディストリビューション等では、これが `lib64` ディレクトリとなるため、起動時にファイルを見つけられず問題となります。

関連案件: project-tsurugi/tsurugi-issues#1066

この問題に対処する修正です。
