### PR TITLE
cache align Iterator members to avoid false sharing

### DIFF
--- a/shirakami/src/Iterator.cpp
+++ b/shirakami/src/Iterator.cpp
@@ -37,16 +37,17 @@ Iterator::Iterator(
     Slice end_key,
     EndPointKind end_kind,
     std::size_t limit,
-    bool reverse) :
+    bool reverse
+) :
     owner_(owner),
-    state_(State::INIT),
     tx_(tx),
     begin_key_(begin_kind == EndPointKind::UNBOUND ? std::string_view{} : begin_key.to_string_view()),
     begin_kind_(begin_kind),
     end_key_(end_kind == EndPointKind::UNBOUND ? std::string_view{} : end_key.to_string_view()),
     end_kind_(end_kind),
     limit_(limit),
-    reverse_(reverse) {}
+    reverse_(reverse)
+{}
 
 Iterator::~Iterator() {
     if(need_scan_close_) {

--- a/shirakami/src/Iterator.h
+++ b/shirakami/src/Iterator.h
@@ -19,6 +19,7 @@
 #include "glog/logging.h"
 #include "shirakami/scheme.h"
 #include "sharksfin/api.h"
+#include "cache_align.h"
 
 namespace sharksfin::shirakami {
 
@@ -93,9 +94,6 @@ public:
 private:
     Storage* owner_{};
     ::shirakami::ScanHandle handle_{};
-    State state_{};
-    std::string buffer_key_{};
-    std::string buffer_value_{};
     Transaction* tx_{};
     std::string begin_key_{};
     EndPointKind begin_kind_{};
@@ -103,8 +101,11 @@ private:
     EndPointKind end_kind_{};
     std::size_t limit_{};
     bool reverse_{};
-    bool key_value_readable_{false};
     bool need_scan_close_{false};
+    sharksfin_cache_align std::string buffer_key_{};
+    sharksfin_cache_align std::string buffer_value_{};
+    sharksfin_cache_align State state_{State::INIT};
+    sharksfin_cache_align bool key_value_readable_{false};
 
     StatusCode next_cursor();
     StatusCode open_cursor();

--- a/shirakami/src/cache_align.h
+++ b/shirakami/src/cache_align.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018-2023 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef SHARKSFIN_SHIRAKAMI_CACHE_ALIGN_H_
+#define SHARKSFIN_SHIRAKAMI_CACHE_ALIGN_H_
+
+#include <new>
+
+/**
+ * @brief qualifier to align on cache lines
+ * @details To avoid false sharing, objects should be cache aligned if
+ * 1. the objects are created(allocated) on one thread and accessed from different threads.
+ * 2. the objects are mutable and changes are made frequently.
+ */
+#ifndef sharksfin_cache_align
+#define sharksfin_cache_align alignas(64)  //NOLINT
+#endif
+
+#endif  // SHARKSFIN_SHIRAKAMI_CACHE_ALIGN_H_


### PR DESCRIPTION
https://github.com/project-tsurugi/tsurugi-issues/issues/1184 で観測された index_field_mapper::process の性能低下に対する予防的な対応として Iterator のメンバで頻繁に更新されるメンバをcache lineにアラインしてfalse sharingの可能性を減らします。
