### PR TITLE
cache align mutable members in Iterator

### DIFF
--- a/shirakami/src/Iterator.cpp
+++ b/shirakami/src/Iterator.cpp
@@ -39,7 +39,6 @@ Iterator::Iterator(
     std::size_t limit,
     bool reverse) :
     owner_(owner),
-    state_(State::INIT),
     tx_(tx),
     begin_key_(begin_kind == EndPointKind::UNBOUND ? std::string_view{} : begin_key.to_string_view()),
     begin_kind_(begin_kind),
@@ -63,20 +62,20 @@ Iterator::~Iterator() {
 }
 
 StatusCode Iterator::next() {
-    if (state_ == State::END) {
+    if (mutables.state_ == State::END) {
         return StatusCode::NOT_FOUND;
     }
-    if (state_ == State::INIT) {
+    if (mutables.state_ == State::INIT) {
         auto rc = open_cursor();
         if(rc == StatusCode::OK) {
-            key_value_readable_ = true;
-            state_ = State::BODY;
+            mutables.key_value_readable_ = true;
+            mutables.state_ = State::BODY;
         }
         return rc;
     }
     auto rc = next_cursor();
     if (rc == StatusCode::OK) {
-        state_ = State::BODY;
+        mutables.state_ = State::BODY;
     }
     return rc;
 }
@@ -84,31 +83,31 @@ StatusCode Iterator::next() {
 // common status code handling for scan functions
 StatusCode Iterator::resolve_scan_errors(Status res) {
     if (res == Status::WARN_SCAN_LIMIT) {
-        state_ = State::SAW_EOF;
+        mutables.state_ = State::SAW_EOF;
     }
     auto rc = resolve(res);
-    key_value_readable_ = rc == StatusCode::OK || rc == StatusCode::CONCURRENT_OPERATION; // even on concurrent_operation, current position is still valid
+    mutables.key_value_readable_ = rc == StatusCode::OK || rc == StatusCode::CONCURRENT_OPERATION; // even on concurrent_operation, current position is still valid
     return rc;
 }
 
 StatusCode Iterator::key(Slice& s) {
-    if (! key_value_readable_) {
+    if (! mutables.key_value_readable_) {
         return StatusCode::ERR_INVALID_STATE;
     }
-    auto res = api::read_key_from_scan(*tx_, handle_, buffer_key_);
+    auto res = api::read_key_from_scan(*tx_, handle_, mutables.buffer_key_);
     tx_->last_call_status(res);
-    s = buffer_key_;
+    s = mutables.buffer_key_;
     correct_transaction_state(*tx_, res);
     return resolve_scan_errors(res);
 }
 
 StatusCode Iterator::value(Slice& s) {
-    if (! key_value_readable_) {
+    if (! mutables.key_value_readable_) {
         return StatusCode::ERR_INVALID_STATE;
     }
-    auto res = api::read_value_from_scan(*tx_, handle_, buffer_value_);
+    auto res = api::read_value_from_scan(*tx_, handle_, mutables.buffer_value_);
     tx_->last_call_status(res);
-    s = buffer_value_;
+    s = mutables.buffer_value_;
     correct_transaction_state(*tx_, res);
     return resolve_scan_errors(res);
 }
@@ -146,7 +145,7 @@ Slice next_neighbor(Slice key) {
 StatusCode Iterator::open_cursor() {
     scan_endpoint begin_endpoint{scan_endpoint::INF};
     scan_endpoint end_endpoint{scan_endpoint::INF};
-    key_value_readable_ = false;
+    mutables.key_value_readable_ = false;
     switch (begin_kind_) {
         case EndPointKind::UNBOUND:
             if(! begin_key_.empty()) {
@@ -168,7 +167,7 @@ StatusCode Iterator::open_cursor() {
             if (n.empty()) {
                 // there is no neighbor - exclude everything
                 begin_key_.clear();
-                state_ = State::END;
+                mutables.state_ = State::END;
                 return StatusCode::NOT_FOUND;
             }
             begin_key_ = n;
@@ -210,7 +209,7 @@ StatusCode Iterator::open_cursor() {
     tx_->last_call_status(res);
     correct_transaction_state(*tx_, res);
     if(res == Status::WARN_NOT_FOUND) {
-        state_ = State::SAW_EOF;
+        mutables.state_ = State::SAW_EOF;
         return StatusCode::NOT_FOUND;
     }
     if(res == Status::OK) {

--- a/shirakami/src/cache_align.h
+++ b/shirakami/src/cache_align.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018-2023 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef SHARKSFIN_SHIRAKAMI_CACHE_ALIGN_H_
+#define SHARKSFIN_SHIRAKAMI_CACHE_ALIGN_H_
+
+#include <new>
+
+/**
+ * @brief qualifier to align on cache lines
+ * @details To avoid false sharing, objects should be cache aligned if
+ * 1. the objects are created(allocated) on one thread and accessed from different threads.
+ * 2. the objects are mutable and changes are made frequently.
+ */
+#ifndef cache_align
+#define cache_align alignas(64)  //NOLINT
+#endif
+
+#endif  // SHARKSFIN_SHIRAKAMI_CACHE_ALIGN_H_


### PR DESCRIPTION
false sharingを防ぐためにIteratorクラスのメモリレイアウトを変更します

- writeが発生する変数を後ろにまとめます
- それらをstructにいれて、64バイトにアラインさせます

paholeの結果(変更後)
```
class Iterator {
public:

        class Storage *            owner_;               /*     0     8 */
        ScanHandle                 handle_;              /*     8     8 */
        class Transaction *        tx_;                  /*    16     8 */
        string                     begin_key_;           /*    24    32 */
        enum EndPointKind          begin_kind_;          /*    56     4 */

        /* XXX 4 bytes hole, try to pack */

        /* --- cacheline 1 boundary (64 bytes) --- */
        string                     end_key_;             /*    64    32 */
        enum EndPointKind          end_kind_;            /*    96     4 */

        /* XXX 4 bytes hole, try to pack */

        size_t                     limit_;               /*   104     8 */
        bool                       reverse_;             /*   112     1 */
        bool                       need_scan_close_;     /*   113     1 */

        /* XXX 14 bytes hole, try to pack */

        /* --- cacheline 2 boundary (128 bytes) --- */
        struct {
                string             buffer_key_;          /*   128    32 */
                string             buffer_value_;        /*   160    32 */
                /* --- cacheline 3 boundary (192 bytes) --- */
                enum State         state_;               /*   192     4 */
                bool               key_value_readable_;  /*   196     1 */
        } __attribute__((__aligned__(64))) mutables __attribute__((__aligned__(64)));     /*   128   128 */

        /* XXX last struct has 59 bytes of padding */

        /* size: 256, cachelines: 4, members: 11 */
        /* sum members: 234, holes: 3, sum holes: 22 */
        /* paddings: 1, sum paddings: 59 */
        /* forced alignments: 1, forced holes: 1, sum forced holes: 14 */
} __attribute__((__aligned__(64)));
```

paholeの結果(変更前)
```
class Iterator {
public:

        class Storage *            owner_;               /*     0     8 */
        ScanHandle                 handle_;              /*     8     8 */
        enum State                 state_;               /*    16     4 */

        /* XXX 4 bytes hole, try to pack */

        string                     buffer_key_;          /*    24    32 */
        string                     buffer_value_;        /*    56    32 */
        /* --- cacheline 1 boundary (64 bytes) was 24 bytes ago --- */
        class Transaction *        tx_;                  /*    88     8 */
        string                     begin_key_;           /*    96    32 */
        /* --- cacheline 2 boundary (128 bytes) --- */
        enum EndPointKind          begin_kind_;          /*   128     4 */

        /* XXX 4 bytes hole, try to pack */

        string                     end_key_;             /*   136    32 */
        enum EndPointKind          end_kind_;            /*   168     4 */

        /* XXX 4 bytes hole, try to pack */

        size_t                     limit_;               /*   176     8 */
        bool                       reverse_;             /*   184     1 */
        bool                       key_value_readable_;  /*   185     1 */
        bool                       need_scan_close_;     /*   186     1 */

        /* size: 192, cachelines: 3, members: 14 */
        /* sum members: 175, holes: 3, sum holes: 12 */
        /* padding: 5 */
};
```