### PR TITLE
build: add build option `BUILD_STRICT`

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -7,6 +7,9 @@ inputs:
   path:
     description: Relative path under $GITHUB_WORKSPACE to place the repository
     default: build-deps
+  cmake_build_option:
+    type: string
+    default: ''
 
 runs:
   using: "composite"
@@ -42,7 +45,7 @@ runs:
         rm -fr build
         mkdir build
         cd build
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_EXAMPLES=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_EXAMPLES=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ${{ inputs.cmake_build_option }} ..
         cmake --build . --target install --clean-first
       shell: bash
 
@@ -52,7 +55,7 @@ runs:
         rm -fr build
         mkdir build
         cd build
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_BENCHMARK=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_BENCHMARK=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ${{ inputs.cmake_build_option }} ..
         cmake --build . --target install --clean-first
       shell: bash
 
@@ -62,6 +65,6 @@ runs:
         rm -fr build
         mkdir build
         cd build
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_BENCHMARK=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_BENCHMARK=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ${{ inputs.cmake_build_option }} ..
         cmake --build . --target install --clean-first
       shell: bash

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -8,6 +8,9 @@ on:
       os:
         type: string
         default: 'ubuntu-22.04'
+      cmake_build_option:
+          type: string
+          default: ''
 
 jobs:
   Test:
@@ -34,12 +37,14 @@ jobs:
 
       - name: Install_Dependencies
         uses: ./.github/actions/install-dependencies
+        with:
+          cmake_build_option: ${{ inputs.cmake_build_option }}
 
       - name: CMake_Build
         run: |
           mkdir build
           cd build
-          cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=ON -DBUILD_MEMORY=ON -DBUILD_EXAMPLES=ON -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/.local ..
+          cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=ON -DBUILD_MEMORY=ON -DBUILD_EXAMPLES=ON -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/.local ${{ inputs.cmake_build_option }} ..
           cmake --build . --target all --clean-first
 
       - name: CTest
@@ -78,13 +83,15 @@ jobs:
 
       - name: Install_Dependencies
         uses: ./.github/actions/install-dependencies
+        with:
+          cmake_build_option: ${{ inputs.cmake_build_option }}
 
       - name: CMake_Generate
         run: |
           rm -rf build
           mkdir build
           cd build
-          cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_MEMORY=ON -DBUILD_EXAMPLES=ON -DBUILD_DOCUMENTS=ON -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/.local -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
+          cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_MEMORY=ON -DBUILD_EXAMPLES=ON -DBUILD_DOCUMENTS=ON -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/.local -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ${{ inputs.cmake_build_option }} ..
 
       - name: Clang-Tidy
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ option(BUILD_MEMORY "Build in-memory implementation" OFF)
 option(BUILD_SHIRAKAMI "Build transaction engine with shirakami" ON)
 option(BUILD_EXAMPLES "Build and test example programs" OFF)
 option(BUILD_DOCUMENTS "Build documents" OFF)
+option(BUILD_STRICT "build with option strictly determine of success" ON)
 option(INSTALL_EXAMPLES "Install example programs" OFF)
 
 option(ENABLE_SANITIZER "enable sanitizer on debug build" ON)

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ available options:
 * `-DBUILD_SHIRAKAMI=OFF` - never build shirakami bridge
 * `-DBUILD_EXAMPLES=ON` - build example programs
 * `-DBUILD_DOCUMENTS=ON` - build documents by doxygen
+* `-DBUILD_STRICT=OFF` - don't treat compile warnings as build errors
 * `-DINSTALL_EXAMPLES=ON` - also install example programs (requires `BUILD_EXAMPLES` is enables)
 * `-DEXAMPLE_IMPLEMENTATION=...` - link the specified target-name implementation to example programs
   * `memory` - link to in-memory implementation

--- a/cmake/CompileOptions.cmake
+++ b/cmake/CompileOptions.cmake
@@ -42,6 +42,11 @@ if(ENABLE_COVERAGE)
 endif()
 
 function(set_compile_options target_name)
-    target_compile_options(${target_name}
-        PRIVATE -Wall -Wextra -Werror)
+    if (BUILD_STRICT)
+        target_compile_options(${target_name}
+            PRIVATE -Wall -Wextra -Werror)
+    else()
+        target_compile_options(${target_name}
+            PRIVATE -Wall -Wextra)
+    endif()
 endfunction(set_compile_options)


### PR DESCRIPTION
Introduced a new `BUILD_STRICT` CMake option to enable strict compilation settings ( with `-Werror` ).
By default, this option is enabled but can be turned off by `-DBUILD_STRICT=OFF`

This PR also enable to specify CMake build option on CI Workflow for workflow_dispatch via `inputs.cmake_build_option`
