### PR TITLE
ci: change Analysis job env to almalinux/clang

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,6 +7,7 @@ bugprone-*,\
 -bugprone-easily-swappable-parameters,\
 cert-*,\
 cppcoreguidelines-*,\
+-cppcoreguidelines-avoid-do-while,\
 -cppcoreguidelines-pro-type-const-cast,\
 fuchsia-*,\
 -fuchsia-default-arguments,\
@@ -32,9 +33,11 @@ misc-*,\
 -misc-const-correctness,\
 -misc-include-cleaner,\
 -misc-unused-parameters,\
+-misc-use-anonymous-namespace,\
 modernize-*,\
 -modernize-use-trailing-return-type,\
 performance-*,\
+-performance-avoid-endl,\
 -performance-enum-size,\
 readability-*,\
 -readability-braces-around-statements,\

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,6 +2,7 @@
 Checks: "-*,\
 abseil-*,\
 boost-*,\
+-boost-use-ranges,\
 bugprone-*,\
 -bugprone-easily-swappable-parameters,\
 cert-*,\
@@ -28,15 +29,21 @@ llvm-*,\
 -llvm-namespace-comment,\
 -llvm-qualified-auto,\
 misc-*,\
+-misc-const-correctness,\
+-misc-include-cleaner,\
 -misc-unused-parameters,\
 modernize-*,\
 -modernize-use-trailing-return-type,\
 performance-*,\
+-performance-enum-size,\
 readability-*,\
 -readability-braces-around-statements,\
 -readability-identifier-length,\
+-readability-math-missing-parentheses,\
 -readability-named-parameter,\
 -readability-qualified-auto,\
+-readability-redundant-inline-specifier,\
+-readability-redundant-member-init,\
 "
 CheckOptions:
   - key: readability-implicit-bool-conversion.AllowPointerConditions

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -65,7 +65,7 @@ jobs:
       checks: write
     timeout-minutes: 30
     container:
-      image: ghcr.io/project-tsurugi/tsurugi-ci:ubuntu-22.04
+      image: ghcr.io/project-tsurugi/tsurugi-ci:almalinux-latest
       volumes:
         - ${{ vars.ccache_dir }}:${{ vars.ccache_dir }}
     defaults:
@@ -73,7 +73,9 @@ jobs:
         shell: bash
     env:
       CCACHE_CONFIGPATH: ${{ vars.ccache_dir }}/ccache.conf
-      CCACHE_DIR: ${{ vars.ccache_dir }}/ubuntu-22.04
+      CCACHE_DIR: ${{ vars.ccache_dir }}/almalinux-latest
+      CC: clang
+      CXX: 'clang++ -march=native'
 
     steps:
       - name: Checkout
@@ -86,16 +88,17 @@ jobs:
         with:
           cmake_build_option: ${{ inputs.cmake_build_option }}
 
-      - name: CMake_Generate
+      - name: CMake_Build
         run: |
           rm -rf build
           mkdir build
           cd build
-          cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_MEMORY=ON -DBUILD_EXAMPLES=ON -DBUILD_DOCUMENTS=ON -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/.local -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ${{ inputs.cmake_build_option }} ..
+          cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_MEMORY=ON -DBUILD_SHIRAKAMI=ON  -DBUILD_TESTS=OFF -DBUILD_EXAMPLES=ON -DBUILD_STRICT=OFF -DBUILD_DOCUMENTS=ON -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/.local -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ${{ inputs.cmake_build_option }} ..
+          cmake --build . --target all --clean-first
 
       - name: Clang-Tidy
         run: |
-          python tools/bin/run-clang-tidy.py -quiet -export-fixes=build/clang-tidy-fix.yaml -p build -extra-arg=-Wno-unknown-warning-option -header-filter=$(pwd)'/(include|memory|shirakami|examples)/.*\\.h$' $(pwd)'/(memory/src|shirakami/src|examples)/.*' 2>&1 | awk '!a[$0]++{print > "build/clang-tidy.log"}'
+          python3 tools/bin/run-clang-tidy.py -quiet -export-fixes=build/clang-tidy-fix.yaml -p build -extra-arg=-Wno-unknown-warning-option -header-filter=$(pwd)'/(include|memory|shirakami|examples)/.*\\.h$' $(pwd)'/(memory/src|shirakami/src|examples)/.*' 2>&1 | awk '!a[$0]++{print > "build/clang-tidy.log"}'
 
       - name: Doxygen
         run: |

--- a/examples/cli/command.cpp
+++ b/examples/cli/command.cpp
@@ -32,7 +32,7 @@ std::vector<CommandSpec> const command_list {  // NOLINT
 };
 
 [[noreturn]] static void raise(StatusCode code) {
-    throw std::runtime_error(to_string_view(code).data());
+    throw std::runtime_error(std::string{to_string_view(code)});
 }
 
 static void check(StatusCode code) {

--- a/memory/src/Environment.cpp
+++ b/memory/src/Environment.cpp
@@ -46,8 +46,8 @@ Environment::Environment() : impl_(std::make_unique<Impl>()) {}
 
 Environment::~Environment() = default;
 
-void Environment::initialize() {
-    impl_->initialize();
+void Environment::initialize() {  // NOLINT(readability-convert-member-functions-to-static)
+    Impl::initialize();
 }
 
 } // namespace sharksfin

--- a/memory/src/api.cpp
+++ b/memory/src/api.cpp
@@ -67,7 +67,7 @@ StatusCode storage_create(DatabaseHandle handle, Slice key, StorageHandle *resul
     log_entry << fn_name << " handle:" << handle << binstring(key);
     auto rc = impl::storage_create(handle, key, result);
     log_rc(rc, fn_name);
-    log_exit << fn_name << " rc:" << rc << " result:" << result;
+    log_exit << fn_name << " rc:" << rc << " result:" << static_cast<void*>(result);
     return rc;
 }
 
@@ -79,7 +79,7 @@ StatusCode storage_create(
     log_entry << fn_name << " handle:" << handle << binstring(key);
     auto rc = impl::storage_create(handle, key, options, result);
     log_rc(rc, fn_name);
-    log_exit << fn_name << " rc:" << rc << " result:" << result;
+    log_exit << fn_name << " rc:" << rc << " result:" << static_cast<void*>(result);
     return rc;
 }
 
@@ -91,7 +91,7 @@ StatusCode storage_create(
     log_entry << fn_name << " handle:" << handle << binstring(key);
     auto rc = impl::storage_create(handle, key, options, result);
     log_rc(rc, fn_name);
-    log_exit << fn_name << " rc:" << rc << " result:" << result;
+    log_exit << fn_name << " rc:" << rc << " result:" << static_cast<void*>(result);
     return rc;
 }
 
@@ -99,7 +99,7 @@ StatusCode storage_get(DatabaseHandle handle, Slice key, StorageHandle *result) 
     log_entry << fn_name << " handle:" << handle << binstring(key);
     auto rc = impl::storage_get(handle, key, result);
     log_rc(rc, fn_name);
-    log_exit << fn_name << " rc:" << rc << " result:" << result;
+    log_exit << fn_name << " rc:" << rc << " result:" << static_cast<void*>(result);
     return rc;
 }
 
@@ -110,7 +110,7 @@ StatusCode storage_get(
     log_entry << fn_name << " handle:" << handle << binstring(key);
     auto rc = impl::storage_get(handle, key, result);
     log_rc(rc, fn_name);
-    log_exit << fn_name << " rc:" << rc << " result:" << result;
+    log_exit << fn_name << " rc:" << rc << " result:" << static_cast<void*>(result);
     return rc;
 }
 

--- a/memory/src/api_helper.cpp
+++ b/memory/src/api_helper.cpp
@@ -504,7 +504,7 @@ StatusCode content_scan_range(
         begin_exclusive ? EndPointKind::EXCLUSIVE : EndPointKind::INCLUSIVE,
         end_key,
         end_key.empty() ? EndPointKind::UNBOUND
-                        : end_exclusive ? EndPointKind::EXCLUSIVE : EndPointKind::INCLUSIVE,
+                        : (end_exclusive ? EndPointKind::EXCLUSIVE : EndPointKind::INCLUSIVE), //NOLINT(readability-avoid-nested-conditional-operator)
         false); // this api is deprecated and reverse is not supported
     *result = wrap(iterator.release());
     return StatusCode::OK;

--- a/shirakami/src/Database.cpp
+++ b/shirakami/src/Database.cpp
@@ -26,7 +26,7 @@
 
 namespace sharksfin::shirakami {
 
-::shirakami::database_options from(DatabaseOptions const& options) {
+static ::shirakami::database_options from(DatabaseOptions const& options) {
     using open_mode = ::shirakami::database_options::open_mode;
     open_mode mode{};
     switch(options.open_mode()) {

--- a/shirakami/src/Environment.cpp
+++ b/shirakami/src/Environment.cpp
@@ -49,8 +49,8 @@ void Environment::Impl::initialize() {
 
 Environment::Impl::~Impl() = default;
 
-void Environment::initialize() {
-    impl_->initialize();
+void Environment::initialize() {  // NOLINT(readability-convert-member-functions-to-static)
+    Impl::initialize();
 }
 
 } // namespace sharksfin

--- a/shirakami/src/Iterator.cpp
+++ b/shirakami/src/Iterator.cpp
@@ -126,8 +126,8 @@ StatusCode Iterator::next_cursor() {
  * @return the next sibling entry key slice
  * @return empty slice if there is no next neighbor (i.e. input key is '0xFFFF....', or empty slice)
  */
-Slice next_neighbor(Slice key) {
-    thread_local std::string buffer {};
+static Slice next_neighbor(Slice key) {
+    thread_local std::string buffer{};  //NOLINT(misc-use-internal-linkage)
     buffer = key.to_string_view();
     bool found = false;
     for (char *iter = (buffer.data() + buffer.size() - 1), *end = buffer.data(); iter >= end; --iter) { // NOLINT

--- a/shirakami/src/Storage.cpp
+++ b/shirakami/src/Storage.cpp
@@ -78,7 +78,7 @@ StatusCode Storage::scan(Transaction* tx,
     return StatusCode::OK;
 }
 
-::shirakami::storage_option from(StorageOptions const& opt) {
+static ::shirakami::storage_option from(StorageOptions const& opt) {
     auto ret = ::shirakami::storage_option{};
     ret.id(opt.storage_id());
     ret.payload(opt.payload());

--- a/shirakami/src/Transaction.h
+++ b/shirakami/src/Transaction.h
@@ -27,7 +27,6 @@
 #include "sharksfin/StatusCode.h"
 #include "Database.h"
 #include "Session.h"
-#include "handle_utils.h"
 
 namespace sharksfin::shirakami {
 

--- a/shirakami/src/api.cpp
+++ b/shirakami/src/api.cpp
@@ -509,9 +509,9 @@ StatusCode content_scan_range(
         IteratorHandle* result) {
     return content_scan(transaction, storage,
             begin_key,
-            begin_key.empty() ? EndPointKind::UNBOUND : (begin_exclusive ? EndPointKind::EXCLUSIVE : EndPointKind::INCLUSIVE),
+            begin_key.empty() ? EndPointKind::UNBOUND : (begin_exclusive ? EndPointKind::EXCLUSIVE : EndPointKind::INCLUSIVE),  //NOLINT(readability-avoid-nested-conditional-operator)
             end_key,
-            end_key.empty() ? EndPointKind::UNBOUND : (end_exclusive ? EndPointKind::EXCLUSIVE : EndPointKind::INCLUSIVE),
+            end_key.empty() ? EndPointKind::UNBOUND : (end_exclusive ? EndPointKind::EXCLUSIVE : EndPointKind::INCLUSIVE),  //NOLINT(readability-avoid-nested-conditional-operator)
             result);
 }
 

--- a/shirakami/src/shirakami_api_helper.cpp
+++ b/shirakami/src/shirakami_api_helper.cpp
@@ -42,7 +42,7 @@ namespace api {
 
 namespace details {
 
-Status sanitize_rc(Status rc) {
+static Status sanitize_rc(Status rc) {
     if(rc >= Status::INTERNAL_BEGIN) {
         ABORT();
     }

--- a/shirakami/test/LongTxTest.cpp
+++ b/shirakami/test/LongTxTest.cpp
@@ -21,6 +21,7 @@
 
 #include "Database.h"
 #include "Iterator.h"
+#include "handle_utils.h"
 
 namespace sharksfin::shirakami {
 

--- a/shirakami/test/TransactionTest.cpp
+++ b/shirakami/test/TransactionTest.cpp
@@ -24,6 +24,7 @@
 
 #include "Database.h"
 #include "Iterator.h"
+#include "handle_utils.h"
 
 namespace sharksfin::shirakami {
 


### PR DESCRIPTION
CI environment changes to enable build compatibility verification with Clang on AlmaLinux and static analysis with new version of Clang-Tidy on Analysis job.