### PR TITLE
ci: improvement for utilization and optimization

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -1,4 +1,5 @@
 name: Sharksfin-Install-Dependencies
+description: Install dependencies for Sharksfin
 
 inputs:
   checkout:
@@ -45,7 +46,7 @@ runs:
         rm -fr build
         mkdir build
         cd build
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_EXAMPLES=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ${{ inputs.cmake_build_option }} ..
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_EXAMPLES=OFF -DBUILD_STRICT=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ${{ inputs.cmake_build_option }} ..
         cmake --build . --target install --clean-first
       shell: bash
 
@@ -55,7 +56,7 @@ runs:
         rm -fr build
         mkdir build
         cd build
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_BENCHMARK=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ${{ inputs.cmake_build_option }} ..
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_BENCHMARK=OFF -DBUILD_STRICT=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ${{ inputs.cmake_build_option }} ..
         cmake --build . --target install --clean-first
       shell: bash
 
@@ -65,6 +66,6 @@ runs:
         rm -fr build
         mkdir build
         cd build
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_BENCHMARK=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ${{ inputs.cmake_build_option }} ..
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_BENCHMARK=OFF -DBUILD_STRICT=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ${{ inputs.cmake_build_option }} ..
         cmake --build . --target install --clean-first
       shell: bash

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -68,12 +68,19 @@ jobs:
       image: ghcr.io/project-tsurugi/tsurugi-ci:almalinux-latest
       volumes:
         - ${{ vars.ccache_dir }}:${{ vars.ccache_dir }}
+        - ${{ vars.ctcache_dir }}:${{ vars.ctcache_dir }}
     defaults:
       run:
         shell: bash
     env:
       CCACHE_CONFIGPATH: ${{ vars.ccache_dir }}/ccache.conf
       CCACHE_DIR: ${{ vars.ccache_dir }}/almalinux-latest
+
+      CTCACHE_DISABLE: ${{ vars.ctcache_disable }}
+      CTCACHE_DIR: ${{ vars.ctcache_dir }}/almalinux-latest
+      CTCACHE_SAVE_OUTPUT: 1
+      CTCACHE_LOCAL: 1
+
       CC: clang
       CXX: 'clang++ -march=native'
 
@@ -98,7 +105,7 @@ jobs:
 
       - name: Clang-Tidy
         run: |
-          python3 tools/bin/run-clang-tidy.py -quiet -export-fixes=build/clang-tidy-fix.yaml -p build -extra-arg=-Wno-unknown-warning-option -header-filter=$(pwd)'/(include|memory|shirakami|examples)/.*\\.h$' $(pwd)'/(memory/src|shirakami/src|examples)/.*' 2>&1 | awk '!a[$0]++{print > "build/clang-tidy.log"}'
+          python3 tools/bin/run-clang-tidy.py -clang-tidy-binary=/opt/ctcache/clang-tidy -quiet -export-fixes=build/clang-tidy-fix.yaml -p build -extra-arg=-Wno-unknown-warning-option -header-filter=$(pwd)'/(include|memory|shirakami|examples)/.*\\.h$' $(pwd)'/(memory/src|shirakami/src|examples)/.*' 2>&1 | awk '!a[$0]++{print > "build/clang-tidy.log"}'
 
       - name: Doxygen
         run: |

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -2,7 +2,11 @@ name: Sharksfin-CI
 
 on:
   push:
+    paths-ignore:
+      - '**.md'
   pull_request:
+    paths-ignore:
+      - '**.md'
   workflow_dispatch:
     inputs:
       os:


### PR DESCRIPTION
This pull request updates the CI workflow configuration to improve efficiency and enable caching for builds and static analysis. The main changes include ignoring markdown files in CI triggers, mounting cache volumes for build tools, setting up environment variables for caching, and specifying a custom `clang-tidy` binary.

**CI Trigger Optimization:**
- Updated the workflow triggers to ignore changes to markdown (`.md`) files, preventing unnecessary CI runs for documentation-only changes.

**Static Analysis Tooling:**
- Modified the `Clang-Tidy` step to use a custom `clang-tidy` binary located at `/opt/ctcache/clang-tidy` for potentially improved caching or performance.

**Dependency Installation Enhancements:**

* Added a description to the `install-dependencies` action for clarity.
* Modified the CMake command in the `install-dependencies` action to disable strict build checks by default (`-DBUILD_STRICT=OFF`).