### PR TITLE
build: bump cmake_minimum_required to 3.20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.20)
 
 if(POLICY CMP0167)
     cmake_policy(SET CMP0167 NEW)


### PR DESCRIPTION
This pull request makes a minor update to the CMake configuration, raising the minimum required CMake version to 3.20.